### PR TITLE
Add initial FastAPI app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,177 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python
+demo/

--- a/.gitignore
+++ b/.gitignore
@@ -174,4 +174,3 @@ poetry.toml
 pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python
-demo/

--- a/{{ cookiecutter.repo_name }}/.env.example
+++ b/{{ cookiecutter.repo_name }}/.env.example
@@ -1,0 +1,1 @@
+KEDRO_ENV=demo

--- a/{{ cookiecutter.repo_name }}/app.py
+++ b/{{ cookiecutter.repo_name }}/app.py
@@ -100,7 +100,12 @@ async def run_pipeline(pipeline_name: str):
                 },
             )
 
+    logger.info(
+        "Pipeline run completed",
+        pipeline_name=pipeline_name,
+        output_vars=list(output.keys()),
+    )
     return {
         "success": True,
-        "output": output,
+        "output_vars": list(output.keys()),
     }

--- a/{{ cookiecutter.repo_name }}/app.py
+++ b/{{ cookiecutter.repo_name }}/app.py
@@ -1,0 +1,106 @@
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from importlib.metadata import version
+
+import structlog
+from fastapi import FastAPI, HTTPException
+from kedro.framework.cli.utils import ENTRY_POINT_GROUPS, _get_entry_points
+from kedro.framework.session import KedroSession
+from kedro.framework.startup import configure_project
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    package_name: str = "{{ cookiecutter.python_package }}"
+    kedro_env: str = "local"
+
+    model_config = SettingsConfigDict(env_file=".env")
+
+
+logger = structlog.get_logger()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """
+    Lifespan event handler for FastAPI to configure Kedro project.
+    """
+    logger.info("Configuring Kedro project...")
+    configure_project(settings.package_name)
+    logger.info("Kedro project configured")
+
+    yield
+
+
+settings = Settings()
+app = FastAPI(lifespan=lifespan)
+
+
+def get_kedro_info():
+    # Inspired by https://github.com/kedro-org/kedro/blob/0.19.12/kedro/framework/cli/cli.py
+    plugin_versions = {}
+    plugin_entry_points = defaultdict(set)
+    for plugin_entry_point in ENTRY_POINT_GROUPS:
+        for entry_point in _get_entry_points(plugin_entry_point):
+            module_name = entry_point.module.split(".")[0]
+            plugin_versions[module_name] = entry_point.dist.version
+            plugin_entry_points[module_name].add(plugin_entry_point)
+
+    return {
+        "kedro_version": version("kedro"),
+        "plugins": plugin_versions,
+        "entry_points": plugin_entry_points,
+    }
+
+
+@app.get("/")
+async def home():
+    return get_kedro_info()
+
+
+@app.get("/registry")
+async def registry():
+    """
+    Returns the pipeline registry of the Kedro project.
+    """
+    from kedro.framework.project import pipelines as pipeline_mapping
+
+    return {
+        "pipelines": [
+            {
+                "name": pipeline_name,
+                "nodes": [
+                    {
+                        "name": node.name,
+                        "inputs": node.inputs,
+                        "outputs": node.outputs,
+                    }
+                    for node in pipeline.nodes
+                ],
+            }
+            for pipeline_name, pipeline in pipeline_mapping.items()
+        ]
+    }
+
+
+@app.post("/run/{pipeline_name}")
+async def run_pipeline(pipeline_name: str):
+    """
+    Runs a Kedro pipeline and returns the result.
+    """
+    with KedroSession.create(env=settings.kedro_env) as session:
+        try:
+            output = session.run(pipeline_name=pipeline_name)
+        except Exception as e:
+            raise HTTPException(
+                500,
+                detail={
+                    "success": False,
+                    "error": str(e),
+                },
+            )
+
+    return {
+        "success": True,
+        "output": output,
+    }

--- a/{{ cookiecutter.repo_name }}/conf/demo/credentials.yml
+++ b/{{ cookiecutter.repo_name }}/conf/demo/credentials.yml
@@ -1,0 +1,3 @@
+openai:
+  openai_api_base: http://localhost:11434/v1/
+  openai_api_key: ollama  # Required, but ignored

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
     "langchain-openai~=0.3.12",
     "kedro-datasets>=3.0",
     "questionary~=2.1.0",
-    "kedro-boot[fastapi]>=0.2.4",
+    "structlog>=25.3.0",
+    "pydantic-settings>=2.9.1",
 ]
 
 [project.scripts]
@@ -44,6 +45,11 @@ dev = [
     "ipython>=8.10",
     "jupyterlab>=3.0",
     "notebook",
+]
+
+[dependency-groups]
+api = [
+    "fastapi[standard]>=0.115.12",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
How to test:

```bash
uvx kedro new --starter . --name example && cd example  # 1. Run the starter itself
mv .env.example .env  # 2. Configure the app
uv run -p 3.12 --group api fastapi dev app.py  # 3. Launch the development server
```

In another terminal:

```bash
curl -X POST -v "http://localhost:8000/run/create_vector_store"  # 4. Trigger a pipeline
```

Known issues:

- Latency is very bad
- #8 
- ~~The `create_vector_store` pipeline fails because of a problem with the `data/` folder, @lrcouto is on it~~
- When the pipeline fails, the error doesn't show in the logs ❗ 

```
                    ERROR    Node                        node.py:392
                             create_vector_store_node:              
                             create_vector_store() ->               
                             failed with error:                     
                                                                    
                    WARNING  There are 1 nodes that    runner.py:338
```

Notes:

- Initially I tried kedro-boot, but I didn't immediately understand it so I wrote my own logic